### PR TITLE
company.py: update class name to artdeco-card.p5.mb4

### DIFF
--- a/linkedin_scraper/company.py
+++ b/linkedin_scraper/company.py
@@ -205,7 +205,7 @@ class Company(Scraper):
             section_id = 3
        #section ID is no longer needed, we are using class name now.
         #grid = driver.find_elements_by_tag_name("section")[section_id]
-        grid = driver.find_element_by_class_name("artdeco-card.p4.mb3")
+        grid = driver.find_element_by_class_name("artdeco-card.p5.mb4")
         print(grid)
         descWrapper = grid.find_elements_by_tag_name("p")
         if len(descWrapper) > 0:
@@ -346,6 +346,6 @@ class Company(Scraper):
         _output['founded'] = self.founded
         _output['affiliated_companies'] = self.affiliated_companies
         _output['employees'] = self.employees
-        
+
         return json.dumps(_output).replace('\n', '')
 


### PR DESCRIPTION
The current version of company.py fails to parse some of the information on LinkedIn company pages. It was failing to find a class called `artdeco-card.p4.mb3`.

The code that looks for `artdeco-card.p4.mb3` is from PR #112. In PR #112, @Alex-Bujorianu says:

> Change the assignment of grid to find the element by the necessary classname (artdeco-card.p4.mb3) instead of the section number. This fixes the issue where a lot of fields were empty/null. But this isn’t very resilient to any changes LinkedIn might make to their classnames. I am not sure if it is better to use this approach or the numbering approach.

Now, the classname on the LinkedIn company pages have replaced the classname `artdeco-card.p4.mb3` with `artdeco-card.p5.mb4`. 

In this PR, I update the classname to `artdeco-card.p5.mb4`. I found that after making this change, company.py works properly again.

Here is an example showing how the LinkedIn company page has a the updated classname:
![example of linkedin company page with artdeco-card.p5.mb4](https://i.ibb.co/7jgzLQ6/artdeco-p5-mb4-2.png)


