### PR TITLE
#136: Refactoring deprecated find_element_by_* and find_elements_by_*

### DIFF
--- a/linkedin_scraper/company.py
+++ b/linkedin_scraper/company.py
@@ -306,7 +306,7 @@ class Company(Scraper):
             driver.find_element(By.ID,"view-other-showcase-pages-dialog").click()
             WebDriverWait(driver, 3).until(EC.presence_of_element_located((By.ID, 'dialog')))
 
-            showcase_pages = driver.find_element(By.CLASS_NAME, "company-showcase-pages")[1]
+            showcase_pages = driver.find_elements(By.CLASS_NAME, "company-showcase-pages")[1]
             for showcase_company in showcase_pages.find_elements(By.TAG_NAME, "li"):
                 name_elem = showcase_company.find_element(By.CLASS_NAME, "name")
                 companySummary = CompanySummary(
@@ -322,7 +322,7 @@ class Company(Scraper):
         # affiliated company
         try:
             affiliated_pages = driver.find_element(By.CLASS_NAME, "affiliated-companies")
-            for i, affiliated_page in enumerate(affiliated_pages.find_element(By.CLASS_NAME, "affiliated-company-name")):
+            for i, affiliated_page in enumerate(affiliated_pages.find_elements(By.CLASS_NAME, "affiliated-company-name")):
                 if i % 3 == 0:
                     affiliated_pages.find_element(By.CLASS_NAME, "carousel-control-next").click()
 

--- a/linkedin_scraper/company.py
+++ b/linkedin_scraper/company.py
@@ -13,7 +13,7 @@ import json
 AD_BANNER_CLASSNAME = ('ad-banner-container', '__ad')
 
 def getchildren(elem):
-    return elem.find_elements_by_xpath(".//*")
+    return elem.find_elements(By.XPATH, ".//*")
 
 class CompanySummary(object):
     linkedin_url = None
@@ -82,7 +82,7 @@ class Company(Scraper):
         return "\n".join(elem.text.split("\n")[1:])
 
     def __get_text_under_subtitle_by_class(self, driver, class_name):
-        return self.__get_text_under_subtitle(driver.find_element_by_class_name(class_name))
+        return self.__get_text_under_subtitle(driver.find_element(By.CLASS_NAME, class_name))
 
     def scrape(self, get_employees=True, close_on_complete=True):
         if self.is_signed_in():
@@ -97,7 +97,7 @@ class Company(Scraper):
             employee_object = {}
             employee_object['name'] = (employee_raw.text.split("\n") or [""])[0].strip()
             employee_object['designation'] = (employee_raw.text.split("\n") or [""])[3].strip()
-            employee_object['linkedin_url'] = employee_raw.find_element_by_tag_name("a").get_attribute("href")
+            employee_object['linkedin_url'] = employee_raw.find_element(By.TAG_NAME, "a").get_attribute("href")
             # print(employee_raw.text, employee_object)
             # _person = Person(
             #     # linkedin_url = employee_raw.find_element_by_tag_name("a").get_attribute("href"),
@@ -134,24 +134,24 @@ class Company(Scraper):
         driver.execute_script("window.scrollTo(0, Math.ceil(document.body.scrollHeight*3/4));")
         time.sleep(1)
 
-        results_list = driver.find_element_by_class_name(list_css)
-        results_li = results_list.find_elements_by_tag_name("li")
+        results_list = driver.find_element(By.CLASS_NAME, list_css)
+        results_li = results_list.find_elements(By.TAG_NAME, "li")
         for res in results_li:
             total.append(self.__parse_employee__(res))
 
         def is_loaded(previous_results):
           loop = 0
           driver.execute_script("window.scrollTo(0, Math.ceil(document.body.scrollHeight));")
-          results_li = results_list.find_elements_by_tag_name("li")
+          results_li = results_list.find_elements(By.TAG_NAME, "li")
           while len(results_li) == previous_results and loop <= 5:
             time.sleep(1)
             driver.execute_script("window.scrollTo(0, Math.ceil(document.body.scrollHeight));")
-            results_li = results_list.find_elements_by_tag_name("li")
+            results_li = results_list.find_elements(By.TAG_NAME, "li")
             loop += 1
           return loop <= 5
 
         def get_data(previous_results):
-            results_li = results_list.find_elements_by_tag_name("li")
+            results_li = results_list.find_elements(By.TAG_NAME, "li")
             for res in results_li[previous_results:]:
                 total.append(self.__parse_employee__(res))
 
@@ -185,15 +185,15 @@ class Company(Scraper):
 
         _ = WebDriverWait(driver, 3).until(EC.presence_of_all_elements_located((By.XPATH, '//span[@dir="ltr"]')))
 
-        navigation = driver.find_element_by_class_name("org-page-navigation__items ")
+        navigation = driver.find_element(By.CLASS_NAME, "org-page-navigation__items ")
 
         self.name = driver.find_element(By.XPATH,'//span[@dir="ltr"]').text.strip()
 
         # Click About Tab or View All Link
         try:
           self.__find_first_available_element__(
-            navigation.find_elements_by_xpath("//a[@data-control-name='page_member_main_nav_about_tab']"),
-            navigation.find_elements_by_xpath("//a[@data-control-name='org_about_module_see_all_view_link']"),
+            navigation.find_elements(By.XPATH, "//a[@data-control-name='page_member_main_nav_about_tab']"),
+            navigation.find_elements(By.XPATH, "//a[@data-control-name='org_about_module_see_all_view_link']"),
           ).click()
         except:
           driver.get(os.path.join(self.linkedin_url, "about"))
@@ -201,19 +201,19 @@ class Company(Scraper):
         _ = WebDriverWait(driver, 3).until(EC.presence_of_all_elements_located((By.TAG_NAME, 'section')))
         time.sleep(3)
 
-        if 'Cookie Policy' in driver.find_elements_by_tag_name("section")[1].text or any(classname in driver.find_elements_by_tag_name("section")[1].get_attribute('class') for classname in AD_BANNER_CLASSNAME):
+        if 'Cookie Policy' in driver.find_elements(By.TAG_NAME, "section")[1].text or any(classname in driver.find_elements(By.TAG_NAME, "section")[1].get_attribute('class') for classname in AD_BANNER_CLASSNAME):
             section_id = 4
         else:
             section_id = 3
        #section ID is no longer needed, we are using class name now.
         #grid = driver.find_elements_by_tag_name("section")[section_id]
-        grid = driver.find_element_by_class_name("artdeco-card.p5.mb4")
+        grid = driver.find_element(By.CLASS_NAME, "artdeco-card.p5.mb4")
         print(grid)
-        descWrapper = grid.find_elements_by_tag_name("p")
+        descWrapper = grid.find_elements(By.TAG_NAME, "p")
         if len(descWrapper) > 0:
             self.about_us = descWrapper[0].text.strip()
-        labels = grid.find_elements_by_tag_name("dt")
-        values = grid.find_elements_by_tag_name("dd")
+        labels = grid.find_elements(By.TAG_NAME, "dt")
+        values = grid.find_elements(By.TAG_NAME, "dd")
         num_attributes = min(len(labels), len(values))
         #print("The length of the labels is " + str(len(labels)), "The length of the values is " + str(len(values)))
         # if num_attributes == 0:
@@ -238,8 +238,8 @@ class Company(Scraper):
             elif txt == 'Specialties':
                 self.specialties = "\n".join(values[i+x_off].text.strip().split(", "))
 
-        grid = driver.find_element_by_class_name("mt1")
-        spans = grid.find_elements_by_tag_name("span")
+        grid = driver.find_element(By.CLASS_NAME, "mt1")
+        spans = grid.find_elements(By.TAG_NAME, "span")
         for span in spans:
             txt = span.text.strip()
             if "See all" in txt and "employees on LinkedIn" in txt:
@@ -250,25 +250,25 @@ class Company(Scraper):
 
         try:
             _ = WebDriverWait(driver, 3).until(EC.presence_of_element_located((By.CLASS_NAME, 'company-list')))
-            showcase, affiliated = driver.find_elements_by_class_name("company-list")
+            showcase, affiliated = driver.find_elements(By.CLASS_NAME, "company-list")
             driver.find_element(By.ID,"org-related-companies-module__show-more-btn").click()
 
             # get showcase
-            for showcase_company in showcase.find_elements_by_class_name("org-company-card"):
+            for showcase_company in showcase.find_elements(By.CLASS_NAME, "org-company-card"):
                 companySummary = CompanySummary(
-                        linkedin_url = showcase_company.find_element_by_class_name("company-name-link").get_attribute("href"),
-                        name = showcase_company.find_element_by_class_name("company-name-link").text.strip(),
-                        followers = showcase_company.find_element_by_class_name("company-followers-count").text.strip()
+                        linkedin_url = showcase_company.find_element(By.CLASS_NAME, "company-name-link").get_attribute("href"),
+                        name = showcase_company.find_element(By.CLASS_NAME, "company-name-link").text.strip(),
+                        followers = showcase_company.find_element(By.CLASS_NAME, "company-followers-count").text.strip()
                     )
                 self.showcase_pages.append(companySummary)
 
             # affiliated company
 
-            for affiliated_company in showcase.find_elements_by_class_name("org-company-card"):
+            for affiliated_company in showcase.find_element(By.CLASS_NAME, "org-company-card"):
                 companySummary = CompanySummary(
-                         linkedin_url = affiliated_company.find_element_by_class_name("company-name-link").get_attribute("href"),
-                        name = affiliated_company.find_element_by_class_name("company-name-link").text.strip(),
-                        followers = affiliated_company.find_element_by_class_name("company-followers-count").text.strip()
+                         linkedin_url = affiliated_company.find_element(By.CLASS_NAME, "company-name-link").get_attribute("href"),
+                        name = affiliated_company.find_element(By.CLASS_NAME, "company-name-link").text.strip(),
+                        followers = affiliated_company.find_element(By.CLASS_NAME, "company-followers-count").text.strip()
                         )
                 self.affiliated_companies.append(companySummary)
 
@@ -290,14 +290,14 @@ class Company(Scraper):
             page = driver.get(self.linkedin_url)
             retry_times = retry_times + 1
 
-        self.name = driver.find_element_by_class_name("name").text.strip()
+        self.name = driver.find_element(By.CLASS_NAME, "name").text.strip()
 
-        self.about_us = driver.find_element_by_class_name("basic-info-description").text.strip()
+        self.about_us = driver.find_element(By.CLASS_NAME, "basic-info-description").text.strip()
         self.specialties = self.__get_text_under_subtitle_by_class(driver, "specialties")
         self.website = self.__get_text_under_subtitle_by_class(driver, "website")
-        self.headquarters = driver.find_element_by_class_name("adr").text.strip()
-        self.industry = driver.find_element_by_class_name("industry").text.strip()
-        self.company_size = driver.find_element_by_class_name("company-size").text.strip()
+        self.headquarters = driver.find_element(By.CLASS_NAME, "adr").text.strip()
+        self.industry = driver.find_element(By.CLASS_NAME, "industry").text.strip()
+        self.company_size = driver.find_element(By.CLASS_NAME, "company-size").text.strip()
         self.company_type = self.__get_text_under_subtitle_by_class(driver, "type")
         self.founded = self.__get_text_under_subtitle_by_class(driver, "founded")
 
@@ -306,28 +306,28 @@ class Company(Scraper):
             driver.find_element(By.ID,"view-other-showcase-pages-dialog").click()
             WebDriverWait(driver, 3).until(EC.presence_of_element_located((By.ID, 'dialog')))
 
-            showcase_pages = driver.find_elements_by_class_name("company-showcase-pages")[1]
-            for showcase_company in showcase_pages.find_elements_by_tag_name("li"):
-                name_elem = showcase_company.find_element_by_class_name("name")
+            showcase_pages = driver.find_element(By.CLASS_NAME, "company-showcase-pages")[1]
+            for showcase_company in showcase_pages.find_elements(By.TAG_NAME, "li"):
+                name_elem = showcase_company.find_element(By.CLASS_NAME, "name")
                 companySummary = CompanySummary(
-                    linkedin_url = name_elem.find_element_by_tag_name("a").get_attribute("href"),
+                    linkedin_url = name_elem.find_element(By.TAG_NAME, "a").get_attribute("href"),
                     name = name_elem.text.strip(),
                     followers = showcase_company.text.strip().split("\n")[1]
                 )
                 self.showcase_pages.append(companySummary)
-            driver.find_element_by_class_name("dialog-close").click()
+            driver.find_element(By.CLASS_NAME, "dialog-close").click()
         except:
             pass
 
         # affiliated company
         try:
-            affiliated_pages = driver.find_element_by_class_name("affiliated-companies")
-            for i, affiliated_page in enumerate(affiliated_pages.find_elements_by_class_name("affiliated-company-name")):
+            affiliated_pages = driver.find_element(By.CLASS_NAME, "affiliated-companies")
+            for i, affiliated_page in enumerate(affiliated_pages.find_element(By.CLASS_NAME, "affiliated-company-name")):
                 if i % 3 == 0:
-                    affiliated_pages.find_element_by_class_name("carousel-control-next").click()
+                    affiliated_pages.find_element(By.CLASS_NAME, "carousel-control-next").click()
 
                 companySummary = CompanySummary(
-                    linkedin_url = affiliated_page.find_element_by_tag_name("a").get_attribute("href"),
+                    linkedin_url = affiliated_page.find_element(By.TAG_NAME, "a").get_attribute("href"),
                     name = affiliated_page.text.strip()
                 )
                 self.affiliated_companies.append(companySummary)

--- a/linkedin_scraper/objects.py
+++ b/linkedin_scraper/objects.py
@@ -68,7 +68,7 @@ class Scraper:
 
     def __find_element_by_class_name__(self, class_name):
         try:
-            self.driver.find_element_by_class_name(class_name)
+            self.driver.find_element(By.CLASS_NAME, class_name)
             return True
         except:
             pass

--- a/linkedin_scraper/person.py
+++ b/linkedin_scraper/person.py
@@ -95,8 +95,8 @@ class Person(Scraper):
             _ = WebDriverWait(self.driver, self.__WAIT_FOR_ELEMENT_TIMEOUT).until(
                 EC.presence_of_element_located((By.CLASS_NAME, class_name))
             )
-            div = self.driver.find_element_by_class_name(class_name)
-            div.find_element_by_tag_name("button").click()
+            div = self.driver.find_element(By.CLASS_NAME, class_name)
+            div.find_element(By.TAG_NAME, "button").click()
         except Exception as e:
             pass
 
@@ -113,7 +113,7 @@ class Person(Scraper):
             )
         )
 
-        self.name = root.find_element_by_class_name(selectors.NAME).text.strip()
+        self.name = root.find_element(By.CLASS_NAME, selectors.NAME).text.strip()
 
         # get about
         try:
@@ -161,26 +161,26 @@ class Person(Scraper):
             exp = None
 
         if exp is not None:
-            for position in exp.find_elements_by_class_name("pv-position-entity"):
-                position_title = position.find_element_by_tag_name("h3").text.strip()
+            for position in exp.find_elements(By.CLASS_NAME, "pv-position-entity"):
+                position_title = position.find_element(By.TAG_NAME, "h3").text.strip()
 
                 try:
-                    company = position.find_elements_by_tag_name("p")[1].text.strip()
+                    company = position.find_elements(By.TAG_NAME, "p")[1].text.strip()
                     times = str(
-                        position.find_elements_by_tag_name("h4")[0]
-                        .find_elements_by_tag_name("span")[1]
+                        position.find_elements(By.TAG_NAME, "h4")[0]
+                        .find_elements(By.TAG_NAME, "span")[1]
                         .text.strip()
                     )
                     from_date = " ".join(times.split(" ")[:2])
                     to_date = " ".join(times.split(" ")[3:])
                     duration = (
-                        position.find_elements_by_tag_name("h4")[1]
-                        .find_elements_by_tag_name("span")[1]
+                        position.find_elements(By.TAG_NAME, "h4")[1]
+                        .find_elements(By.TAG_NAME, "span")[1]
                         .text.strip()
                     )
                     location = (
-                        position.find_elements_by_tag_name("h4")[2]
-                        .find_elements_by_tag_name("span")[1]
+                        position.find_elements(By.TAG_NAME, "h4")[2]
+                        .find_elements(By.TAG_NAME, "span")[1]
                         .text.strip()
                     )
                 except:
@@ -198,8 +198,8 @@ class Person(Scraper):
                 self.add_experience(experience)
 
         # get location
-        location = driver.find_element_by_class_name(f"{self.__TOP_CARD}--list-bullet")
-        location = location.find_element_by_tag_name("li").text
+        location = driver.find_element(By.CLASS_NAME, f"{self.__TOP_CARD}--list-bullet")
+        location = location.find_element(By.TAG_NAME, "li").text
         self.add_location(location)
 
         driver.execute_script(
@@ -217,22 +217,22 @@ class Person(Scraper):
         except:
             edu = None
         if edu:
-            for school in edu.find_elements_by_class_name(
+            for school in edu.find_elements(By.CLASS_NAME, 
                 "pv-profile-section__list-item"
             ):
-                university = school.find_element_by_class_name(
+                university = school.find_element(By.CLASS_NAME, 
                     "pv-entity__school-name"
                 ).text.strip()
 
                 try:
                     degree = (
-                        school.find_element_by_class_name("pv-entity__degree-name")
-                        .find_elements_by_tag_name("span")[1]
+                        school.find_element(By.CLASS_NAME, "pv-entity__degree-name")
+                        .find_elements(By.TAG_NAME, "span")[1]
                         .text.strip()
                     )
                     times = (
-                        school.find_element_by_class_name("pv-entity__dates")
-                        .find_elements_by_tag_name("span")[1]
+                        school.find_element(By.CLASS_NAME, "pv-entity__dates")
+                        .find_elements(By.TAG_NAME, "span")[1]
                         .text.strip()
                     )
                     from_date, to_date = (times.split(" ")[0], times.split(" ")[2])
@@ -259,11 +259,11 @@ class Person(Scraper):
             interestContainer = driver.find_element(By.XPATH,
                 "//*[@class='pv-profile-section pv-interests-section artdeco-container-card artdeco-card ember-view']"
             )
-            for interestElement in interestContainer.find_elements_by_xpath(
+            for interestElement in interestContainer.find_elements(By.XPATH, 
                 "//*[@class='pv-interest-entity pv-profile-section__card-item ember-view']"
             ):
                 interest = Interest(
-                    interestElement.find_element_by_tag_name("h3").text.strip()
+                    interestElement.find_element(By.TAG_NAME, "h3").text.strip()
                 )
                 self.add_interest(interest)
         except:
@@ -282,13 +282,13 @@ class Person(Scraper):
             acc = driver.find_element(By.XPATH,
                 "//*[@class='pv-profile-section pv-accomplishments-section artdeco-container-card artdeco-card ember-view']"
             )
-            for block in acc.find_elements_by_xpath(
+            for block in acc.find_elements(By.XPATH, 
                 "//div[@class='pv-accomplishments-block__content break-words']"
             ):
-                category = block.find_element_by_tag_name("h3")
-                for title in block.find_element_by_tag_name(
+                category = block.find_element(By.TAG_NAME, "h3")
+                for title in block.find_element(By.TAG_NAME, 
                     "ul"
-                ).find_elements_by_tag_name("li"):
+                ).find_elements(By.TAG_NAME, "li"):
                     accomplishment = Accomplishment(category.text, title.text)
                     self.add_accomplishment(accomplishment)
         except:
@@ -300,13 +300,13 @@ class Person(Scraper):
             _ = WebDriverWait(driver, self.__WAIT_FOR_ELEMENT_TIMEOUT).until(
                 EC.presence_of_element_located((By.CLASS_NAME, "mn-connections"))
             )
-            connections = driver.find_element_by_class_name("mn-connections")
+            connections = driver.find_element(By.CLASS_NAME, "mn-connections")
             if connections is not None:
-                for conn in connections.find_elements_by_class_name("mn-connection-card"):
-                    anchor = conn.find_element_by_class_name("mn-connection-card__link")
+                for conn in connections.find_elements(By.CLASS_NAME, "mn-connection-card"):
+                    anchor = conn.find_element(By.CLASS_NAME, "mn-connection-card__link")
                     url = anchor.get_attribute("href")
-                    name = conn.find_element_by_class_name("mn-connection-card__details").find_element_by_class_name("mn-connection-card__name").text.strip()
-                    occupation = conn.find_element_by_class_name("mn-connection-card__details").find_element_by_class_name("mn-connection-card__occupation").text.strip()
+                    name = conn.find_element(By.CLASS_NAME, "mn-connection-card__details").find_element(By.CLASS_NAME, "mn-connection-card__name").text.strip()
+                    occupation = conn.find_element(By.CLASS_NAME, "mn-connection-card__details").find_element(By.CLASS_NAME, "mn-connection-card__occupation").text.strip()
 
                     contact = Contact(name=name, occupation=occupation, url=url)
                     self.add_contact(contact)
@@ -324,7 +324,7 @@ class Person(Scraper):
             retry_times = retry_times + 1
 
         # get name
-        self.name = driver.find_element_by_class_name(
+        self.name = driver.find_element(By.CLASS_NAME, 
             "top-card-layout__title"
         ).text.strip()
 
@@ -333,38 +333,38 @@ class Person(Scraper):
             _ = WebDriverWait(driver, self.__WAIT_FOR_ELEMENT_TIMEOUT).until(
                 EC.presence_of_element_located((By.CLASS_NAME, "experience"))
             )
-            exp = driver.find_element_by_class_name("experience")
+            exp = driver.find_element(By.CLASS_NAME, "experience")
         except:
             exp = None
 
         if exp is not None:
-            for position in exp.find_elements_by_class_name(
+            for position in exp.find_elements(By.CLASS_NAME, 
                 "experience-item__contents"
             ):
-                position_title = position.find_element_by_class_name(
+                position_title = position.find_element(By.CLASS_NAME, 
                     "experience-item__title"
                 ).text.strip()
-                company = position.find_element_by_class_name(
+                company = position.find_element(By.CLASS_NAME, 
                     "experience-item__subtitle"
                 ).text.strip()
 
                 try:
-                    times = position.find_element_by_class_name(
+                    times = position.find_element(By.CLASS_NAME, 
                         "experience-item__duration"
                     )
-                    from_date = times.find_element_by_class_name(
+                    from_date = times.find_element(By.CLASS_NAME, 
                         "date-range__start-date"
                     ).text.strip()
                     try:
-                        to_date = times.find_element_by_class_name(
+                        to_date = times.find_element(By.CLASS_NAME, 
                             "date-range__end-date"
                         ).text.strip()
                     except:
                         to_date = "Present"
-                    duration = position.find_element_by_class_name(
+                    duration = position.find_element(By.CLASS_NAME, 
                         "date-range__duration"
                     ).text.strip()
-                    location = position.find_element_by_class_name(
+                    location = position.find_element(By.CLASS_NAME, 
                         "experience-item__location"
                     ).text.strip()
                 except:
@@ -384,20 +384,20 @@ class Person(Scraper):
         )
 
         # get education
-        edu = driver.find_element_by_class_name("education__list")
-        for school in edu.find_elements_by_class_name("result-card"):
-            university = school.find_element_by_class_name(
+        edu = driver.find_element(By.CLASS_NAME, "education__list")
+        for school in edu.find_elements(By.CLASS_NAME, "result-card"):
+            university = school.find_element(By.CLASS_NAME, 
                 "result-card__title"
             ).text.strip()
-            degree = school.find_element_by_class_name(
+            degree = school.find_element(By.CLASS_NAME, 
                 "education__item--degree-info"
             ).text.strip()
             try:
-                times = school.find_element_by_class_name("date-range")
-                from_date = times.find_element_by_class_name(
+                times = school.find_element(By.CLASS_NAME, "date-range")
+                from_date = times.find_element(By.CLASS_NAME, 
                     "date-range__start-date"
                 ).text.strip()
-                to_date = times.find_element_by_class_name(
+                to_date = times.find_element(By.CLASS_NAME, 
                     "date-range__end-date"
                 ).text.strip()
             except:


### PR DESCRIPTION
Methods are deprecated and will either generate an error or a deprecation warning (see: https://stackoverflow.com/questions/69875125/find-element-by-commands-are-deprecated-in-selenium).

All references should be replaced by the relevant By class method (see: https://selenium-python.readthedocs.io/locating-elements.html). This will resolve errors for users on newer versions of chromedriver.

FWIW – interestingly By is already in the import path of all relevant files and inconsistently used throughout. This PR should resolve those confusing inconsistencies as well (e.g. use of both find_element_by_xpath and find_element(By.XPATH in the same class).