### PR TITLE
fix error missing fields in linkedin pages

### DIFF
--- a/linkedin_scraper/jobs.py
+++ b/linkedin_scraper/jobs.py
@@ -1,3 +1,5 @@
+from selenium.common import TimeoutException
+
 from .objects import Scraper
 from . import constants as c
 from selenium.webdriver.common.by import By
@@ -57,7 +59,10 @@ class Job(Scraper):
         self.company_linkedin_url = self.wait_for_element_to_load(name="jobs-unified-top-card__company-name").find_element_by_tag_name("a").get_attribute("href")
         self.location = self.wait_for_element_to_load(name="jobs-unified-top-card__bullet").text.strip()
         self.posted_date = self.wait_for_element_to_load(name="jobs-unified-top-card__posted-date").text.strip()
-        self.applicant_count = self.wait_for_element_to_load(name="jobs-unified-top-card__applicant-count").text.strip()
+        try:
+            self.applicant_count = self.wait_for_element_to_load(name="jobs-unified-top-card__applicant-count").text.strip()
+        except TimeoutException:
+            self.applicant_count = 0
         self.job_description = self.wait_for_element_to_load(name="jobs-description").text.strip()
         self.benefits = self.wait_for_element_to_load(name="jobs-unified-description__salary-main-rail-card").text.strip()
 

--- a/linkedin_scraper/jobs.py
+++ b/linkedin_scraper/jobs.py
@@ -1,4 +1,4 @@
-from selenium.common import TimeoutException
+from selenium.common.exceptions import TimeoutException
 
 from .objects import Scraper
 from . import constants as c

--- a/linkedin_scraper/person.py
+++ b/linkedin_scraper/person.py
@@ -214,10 +214,17 @@ class Person(Scraper):
 
             institution_name = outer_positions[0].find_element_by_tag_name("span").find_element_by_tag_name("span").text
             degree = outer_positions[1].find_element_by_tag_name("span").text
-            times = outer_positions[2].find_element_by_tag_name("span").text
 
-            from_date = " ".join(times.split(" ")[:2])
-            to_date = " ".join(times.split(" ")[3:])
+            if len(outer_positions) > 2:
+                times = outer_positions[2].find_element_by_tag_name("span").text
+
+                from_date = " ".join(times.split(" ")[:2])
+                to_date = " ".join(times.split(" ")[3:])
+            else:
+                from_date = None
+                to_date = None
+
+
 
             description = position_summary_text.text if position_summary_text else ""
 

--- a/linkedin_scraper/person.py
+++ b/linkedin_scraper/person.py
@@ -3,6 +3,7 @@ from selenium import webdriver
 from selenium.webdriver.common.by import By
 from selenium.webdriver.support.ui import WebDriverWait
 from selenium.webdriver.support import expected_conditions as EC
+from selenium.common.exceptions import NoSuchElementException
 from .objects import Experience, Education, Scraper, Interest, Accomplishment, Contact
 import os
 from linkedin_scraper import selectors
@@ -245,9 +246,11 @@ class Person(Scraper):
 
 
     def get_about(self):
-        about = self.driver.find_element_by_id("about").find_element_by_xpath("..").find_element_by_class_name("display-flex").text
+        try:
+            about = self.driver.find_element_by_id("about").find_element_by_xpath("..").find_element_by_class_name("display-flex").text
+        except NoSuchElementException :
+            about=None
         self.about = about
-
 
     def scrape_logged_in(self, close_on_complete=True):
         driver = self.driver


### PR DESCRIPTION
Fix 'list index out of range' error in row 217 of 'person' for cases where 'outer_positions' has length <=2 and there are no dates for the education section.