### PR TITLE
fix job_search AttributeError

### DIFF
--- a/linkedin_scraper/job_search.py
+++ b/linkedin_scraper/job_search.py
@@ -36,8 +36,8 @@ class JobSearch(Scraper):
         job_div = self.wait_for_element_to_load(name="job-card-list__title", base=base_element)
         job_title = job_div.text.strip()
         linkedin_url = job_div.get_attribute("href")
-        company = base_element.find_element_by_class_name("job-card-container__primary-description").text
-        location = base_element.find_element_by_class_name("job-card-container__metadata-item").text
+        company = base_element.find_element(By.CLASS_NAME, "job-card-container__primary-description").text
+        location = base_element.find_element(By.CLASS_NAME, "job-card-container__metadata-item").text
         job = Job(linkedin_url=linkedin_url, job_title=job_title, company=company, location=location, scrape=False, driver=self.driver)
         return job
 


### PR DESCRIPTION
This commit fixed the error described as 'AttributeError: 'WebElement' doesn't have 'find_elements_by_class_name' attribute when using job_search. It changed `.find_elements_by_class_name("[CLASSNAME]")` to `.find_element(By.CLASS_NAME, "[CLASSNAME]")`.