### PR TITLE
set default values for Person attributes

### DIFF
--- a/linkedin_scraper/person.py
+++ b/linkedin_scraper/person.py
@@ -127,6 +127,8 @@ class Person(Scraper):
             position_summary_text = position_details_list[1] if len(position_details_list) > 1 else None
             outer_positions = position_summary_details.find_element(By.XPATH,"*").find_elements(By.XPATH,"*")
 
+            company = ""
+            work_times = ""
             if len(outer_positions) == 4:
                 position_title = outer_positions[0].find_element(By.TAG_NAME,"span").text
                 company = outer_positions[1].find_element(By.TAG_NAME,"span").text


### PR DESCRIPTION
this commit adds a default value (empty string) to some locally defined variables, to allow them to be used in a global context.

this handles the following error:
```
UnboundLocalError: cannot access local variable '<>' where it is not associated with a value
```