### PR TITLE
Fix for some LI profiles where there are only 2 elements

### DIFF
--- a/linkedin_scraper/person.py
+++ b/linkedin_scraper/person.py
@@ -206,7 +206,12 @@ class Person(Scraper):
         main = self.wait_for_element_to_load(by=By.TAG_NAME, name="main")
         self.scroll_to_half()
         self.scroll_to_bottom()
-        main_list = self.wait_for_element_to_load(name="pvs-list", base=main)
+        try:
+            main_list = self.wait_for_element_to_load(name="pvs-list", base=main)
+        except:
+            # if education is hidden, this value will not be shown
+            return
+    
         for position in main_list.find_elements(By.CLASS_NAME,"pvs-entity"):
             institution_logo_elem, position_details = position.find_elements(By.XPATH,"*")
 

--- a/linkedin_scraper/person.py
+++ b/linkedin_scraper/person.py
@@ -127,6 +127,7 @@ class Person(Scraper):
             position_summary_text = position_details_list[1] if len(position_details_list) > 1 else None
             outer_positions = position_summary_details.find_element(By.XPATH,"*").find_elements(By.XPATH,"*")
 
+            work_times = ""
             if len(outer_positions) == 4:
                 position_title = outer_positions[0].find_element(By.TAG_NAME,"span").text
                 company = outer_positions[1].find_element(By.TAG_NAME,"span").text
@@ -143,6 +144,11 @@ class Person(Scraper):
                     company = outer_positions[0].find_element(By.TAG_NAME,"span").text
                     work_times = outer_positions[1].find_element(By.TAG_NAME,"span").text
                     location = outer_positions[2].find_element(By.TAG_NAME,"span").text
+            elif len(outer_positions) == 2:
+                position_title = ""
+                company = outer_positions[0].find_element(By.TAG_NAME,"span").text
+                work_times = outer_positions[1].find_element(By.TAG_NAME,"span").text
+                location = ""
 
             times = work_times.split("·")[0].strip() if work_times else ""
             duration = work_times.split("·")[1].strip() if len(work_times.split("·")) > 1 else None

--- a/linkedin_scraper/person.py
+++ b/linkedin_scraper/person.py
@@ -32,6 +32,7 @@ class Person(Scraper):
         close_on_complete=True,
         time_to_wait_after_login=0,
     ):
+        self.open_to_work = None
         self.linkedin_url = linkedin_url
         self.name = name
         self.about = about or []


### PR DESCRIPTION
Some LI profiles only have 2 elements, particularly if the individual has been promoted.
Updated the code for this use case.