### PR TITLE
feat: enhance person scraper with employment type extraction and grouped experience parsing

### DIFF
--- a/linkedin_scraper/models/person.py
+++ b/linkedin_scraper/models/person.py
@@ -21,6 +21,7 @@ class Experience(BaseModel):
 
     position_title: Optional[str] = None
     institution_name: Optional[str] = None
+    employment_type: Optional[str] = None
     linkedin_url: Optional[str] = None
     from_date: Optional[str] = None
     to_date: Optional[str] = None

--- a/linkedin_scraper/scrapers/person.py
+++ b/linkedin_scraper/scrapers/person.py
@@ -1,7 +1,8 @@
 """Person/Profile scraper for LinkedIn."""
 
 import logging
-from typing import Optional
+import re
+from typing import Optional, Union
 from urllib.parse import urljoin
 from playwright.async_api import Page
 
@@ -11,6 +12,18 @@ from ..callbacks import ProgressCallback, SilentCallback
 from ..core.exceptions import ScrapingError
 
 logger = logging.getLogger(__name__)
+
+EMPLOYMENT_TYPE_MAP = {
+    "full-time": "Full-time",
+    "part-time": "Part-time",
+    "self-employed": "Self-employed",
+    "freelance": "Freelance",
+    "contract": "Contract",
+    "internship": "Internship",
+    "apprenticeship": "Apprenticeship",
+    "seasonal": "Seasonal",
+    "temporary": "Temporary",
+}
 
 
 class PersonScraper(BaseScraper):
@@ -157,60 +170,23 @@ class PersonScraper(BaseScraper):
             return None
 
     async def _get_experiences(self, base_url: str) -> list[Experience]:
-        """Extract experiences from the main profile page Experience section."""
+        """Extract experiences from details page with main-page fallback."""
         experiences = []
 
         try:
-            experience_heading = self.page.locator('h2:has-text("Experience")').first
-            
-            if await experience_heading.count() > 0:
-                experience_section = experience_heading.locator('xpath=ancestor::*[.//ul or .//ol][1]')
-                if await experience_section.count() == 0:
-                    experience_section = experience_heading.locator('xpath=ancestor::*[4]')
-                
-                if await experience_section.count() > 0:
-                    items = await experience_section.locator('ul > li, ol > li').all()
-                    
-                    for item in items:
-                        try:
-                            exp = await self._parse_main_page_experience(item)
-                            if exp:
-                                experiences.append(exp)
-                        except Exception as e:
-                            logger.debug(f"Error parsing experience from main page: {e}")
-                            continue
-            
+            try:
+                experiences = await self._get_experiences_from_details(base_url)
+            except Exception as e:
+                logger.debug(f"Error loading experience details page: {e}")
+                experiences = []
+
             if not experiences:
-                exp_url = urljoin(base_url, "details/experience")
-                await self.navigate_and_wait(exp_url)
+                await self.navigate_and_wait(base_url)
                 await self.page.wait_for_selector("main", timeout=10000)
                 await self.wait_and_focus(1.5)
                 await self.scroll_page_to_half()
-                await self.scroll_page_to_bottom(pause_time=0.5, max_scrolls=5)
-
-                items = []
-                main_element = self.page.locator('main')
-                if await main_element.count() > 0:
-                    list_items = await main_element.locator('list > listitem, ul > li').all()
-                    if list_items:
-                        items = list_items
-                
-                if not items:
-                    old_list = self.page.locator(".pvs-list__container").first
-                    if await old_list.count() > 0:
-                        items = await old_list.locator(".pvs-list__paged-list-item").all()
-
-                for item in items:
-                    try:
-                        result = await self._parse_experience_item(item)
-                        if result:
-                            if isinstance(result, list):
-                                experiences.extend(result)
-                            else:
-                                experiences.append(result)
-                    except Exception as e:
-                        logger.debug(f"Error parsing experience item: {e}")
-                        continue
+                await self.scroll_page_to_bottom(pause_time=0.5, max_scrolls=3)
+                experiences = await self._get_experiences_from_main_page()
 
         except Exception as e:
             logger.warning(
@@ -218,8 +194,96 @@ class PersonScraper(BaseScraper):
             )
 
         return experiences
+
+    async def _get_experiences_from_details(self, base_url: str) -> list[Experience]:
+        """Extract experiences from the details/experience page."""
+        experiences = []
+
+        exp_url = urljoin(base_url, "details/experience")
+        await self.navigate_and_wait(exp_url)
+        await self.page.wait_for_selector("main", timeout=10000)
+        await self.wait_and_focus(1.5)
+        await self.scroll_page_to_half()
+        await self.scroll_page_to_bottom(pause_time=0.5, max_scrolls=5)
+
+        items = []
+        main_element = self.page.locator("main")
+        if await main_element.count() > 0:
+            top_container = main_element.locator(".pvs-list__container").first
+            if await top_container.count() > 0:
+                top_items = await top_container.locator(
+                    "> .scaffold-finite-scroll > .scaffold-finite-scroll__content > ul > li"
+                ).all()
+                if top_items:
+                    items = top_items
+
+            if not items:
+                list_items = await main_element.locator("list > listitem, ul > li").all()
+                if list_items:
+                    filtered = []
+                    for list_item in list_items:
+                        in_sub = await list_item.locator(
+                            'xpath=ancestor::*[contains(concat(" ", normalize-space(@class), " "), " pvs-entity__sub-components ")]'
+                        ).count()
+                        if in_sub == 0:
+                            filtered.append(list_item)
+                    items = filtered
+
+        if not items:
+            old_list = self.page.locator(".pvs-list__container").first
+            if await old_list.count() > 0:
+                items = await old_list.locator(".pvs-list__paged-list-item").all()
+
+        for item in items:
+            try:
+                result = await self._parse_experience_item(item)
+                if result:
+                    if isinstance(result, list):
+                        experiences.extend(result)
+                    else:
+                        experiences.append(result)
+            except Exception as e:
+                logger.debug(f"Error parsing experience item: {e}")
+                continue
+
+        return experiences
+
+    async def _get_experiences_from_main_page(self) -> list[Experience]:
+        """Extract experiences from the main profile page Experience section."""
+        experiences = []
+
+        experience_heading = self.page.locator('h2:has-text("Experience")').first
+        if await experience_heading.count() == 0:
+            return experiences
+
+        experience_section = experience_heading.locator(
+            'xpath=ancestor::*[.//ul or .//ol][1]'
+        )
+        if await experience_section.count() == 0:
+            experience_section = experience_heading.locator('xpath=ancestor::*[4]')
+
+        if await experience_section.count() == 0:
+            return experiences
+
+        items = await experience_section.locator("ul > li, ol > li").all()
+
+        for item in items:
+            try:
+                exp = await self._parse_main_page_experience(item)
+                if exp:
+                    if isinstance(exp, list):
+                        experiences.extend(exp)
+                    else:
+                        experiences.append(exp)
+            except Exception as e:
+                logger.debug(f"Error parsing experience from main page: {e}")
+                continue
+
+        return experiences
     
-    async def _parse_main_page_experience(self, item) -> Optional[Experience]:
+    async def _parse_main_page_experience(
+        self, item
+    ) -> Optional[Union[Experience, list[Experience]]]:
         """Parse experience from main profile page list item with [logo_link, details_link] structure."""
         try:
             links = await item.locator('a').all()
@@ -231,11 +295,39 @@ class PersonScraper(BaseScraper):
             
             unique_texts = await self._extract_unique_texts_from_element(detail_link)
             
+            if not unique_texts:
+                return None
+
+            nested_roles = await item.locator(
+                '.pvs-entity__sub-components div[data-view-name="profile-component-entity"]'
+            ).all()
+            if nested_roles:
+                company_name, employment_type = self._split_company_and_employment_type(
+                    unique_texts[0]
+                )
+                if not employment_type:
+                    for text in unique_texts[1:]:
+                        employment_type = self._extract_employment_type_from_text(text)
+                        if employment_type:
+                            break
+                grouped_experiences = []
+                for nested_item in nested_roles:
+                    exp = await self._parse_grouped_main_page_role(
+                        nested_item, company_name, company_url, employment_type
+                    )
+                    if exp:
+                        grouped_experiences.append(exp)
+                if grouped_experiences:
+                    return grouped_experiences
+                return None
+
             if len(unique_texts) < 2:
                 return None
             
             position_title = unique_texts[0]
-            company_name = unique_texts[1]
+            company_name, employment_type = self._split_company_and_employment_type(
+                unique_texts[1]
+            )
             work_times = unique_texts[2] if len(unique_texts) > 2 else ""
             
             from_date, to_date, duration = self._parse_work_times(work_times)
@@ -243,6 +335,7 @@ class PersonScraper(BaseScraper):
             return Experience(
                 position_title=position_title,
                 institution_name=company_name,
+                employment_type=employment_type,
                 linkedin_url=company_url,
                 from_date=from_date,
                 to_date=to_date,
@@ -275,49 +368,153 @@ class PersonScraper(BaseScraper):
         
         return unique_texts
 
+    async def _parse_grouped_main_page_role(
+        self,
+        item,
+        company_name: str,
+        company_url: Optional[str],
+        employment_type: Optional[str],
+    ) -> Optional[Experience]:
+        """Parse a grouped role under a company on the main page."""
+        try:
+            detail_link = item.locator("a").first
+            target = detail_link if await detail_link.count() > 0 else item
+            unique_texts = await self._extract_unique_texts_from_element(target)
+
+            if company_name:
+                unique_texts = [
+                    text
+                    for text in unique_texts
+                    if text.strip() != company_name.strip()
+                ]
+
+            if not unique_texts:
+                return None
+
+            position_title = unique_texts[0]
+            work_times = ""
+            location = ""
+
+            for text in unique_texts[1:]:
+                if not work_times and self._is_experience_time_text(text):
+                    work_times = text
+                    continue
+                if not location:
+                    location = text
+
+            if not company_url and await detail_link.count() > 0:
+                company_url = await detail_link.get_attribute("href")
+
+            from_date, to_date, duration = self._parse_work_times(work_times)
+
+            return Experience(
+                position_title=position_title.strip(),
+                institution_name=company_name.strip() if company_name else None,
+                employment_type=employment_type,
+                linkedin_url=company_url,
+                from_date=from_date,
+                to_date=to_date,
+                duration=duration,
+                location=location.strip() if location else None,
+                description=None,
+            )
+
+        except Exception as e:
+            logger.debug(f"Error parsing grouped main page experience: {e}")
+            return None
+
+    def _is_experience_time_text(self, text: str) -> bool:
+        if not text:
+            return False
+
+        text = text.strip()
+        if " - " in text or "Present" in text:
+            return True
+
+        if re.search(r"\b(19|20)\d{2}\b", text):
+            return True
+
+        for month in [
+            "Jan",
+            "Feb",
+            "Mar",
+            "Apr",
+            "May",
+            "Jun",
+            "Jul",
+            "Aug",
+            "Sep",
+            "Oct",
+            "Nov",
+            "Dec",
+        ]:
+            if month in text:
+                return True
+
+        return False
+
+    def _normalize_employment_type(self, text: str) -> str:
+        normalized = text.lower()
+        normalized = re.sub(r"[\u2013\u2014]", "-", normalized)
+        normalized = re.sub(r"\s+", " ", normalized).strip()
+        normalized = normalized.replace(" ", "-")
+        return normalized
+
+    def _extract_employment_type_from_text(self, text: Optional[str]) -> Optional[str]:
+        if not text:
+            return None
+
+        parts = [
+            part.strip()
+            for part in re.split(r"[\u00b7\u2022]", text)
+            if part.strip()
+        ]
+        for part in parts:
+            normalized = self._normalize_employment_type(part)
+            if normalized in EMPLOYMENT_TYPE_MAP:
+                return EMPLOYMENT_TYPE_MAP[normalized]
+
+        normalized_text = self._normalize_employment_type(text)
+        for key, value in EMPLOYMENT_TYPE_MAP.items():
+            if normalized_text.startswith(key):
+                return value
+
+        return None
+
+    def _split_company_and_employment_type(
+        self, text: str
+    ) -> tuple[str, Optional[str]]:
+        if not text:
+            return text, None
+
+        parts = [
+            part.strip()
+            for part in re.split(r"[\u00b7\u2022]", text)
+            if part.strip()
+        ]
+        if len(parts) >= 2:
+            for part in parts[1:]:
+                employment_type = self._extract_employment_type_from_text(part)
+                if employment_type:
+                    return parts[0], employment_type
+
+        return text, None
+
     async def _parse_experience_item(self, item):
         """Parse experience item. Returns Experience or list for nested positions."""
         try:
-            links = await item.locator('a, link').all()
-            if len(links) >= 2:
-                company_url = await links[0].get_attribute('href')
-                detail_link = links[1]
-                
-                generics = await detail_link.locator('generic, span, div').all()
-                texts = []
-                for g in generics:
-                    text = await g.text_content()
-                    if text and text.strip() and len(text.strip()) < 200:
-                        texts.append(text.strip())
-                
-                unique_texts = list(dict.fromkeys(texts))
-                
-                if len(unique_texts) >= 2:
-                    position_title = unique_texts[0]
-                    company_name = unique_texts[1]
-                    work_times = unique_texts[2] if len(unique_texts) > 2 else ""
-                    location = unique_texts[3] if len(unique_texts) > 3 else ""
-                    
-                    from_date, to_date, duration = self._parse_work_times(work_times)
-                    
-                    return Experience(
-                        position_title=position_title,
-                        institution_name=company_name,
-                        linkedin_url=company_url,
-                        from_date=from_date,
-                        to_date=to_date,
-                        duration=duration,
-                        location=location,
-                        description=None,
-                    )
-            
+            if await self._is_grouped_experience_item(item):
+                grouped = await self._parse_grouped_details_experience(item)
+                if grouped:
+                    return grouped
+
             entity = item.locator('div[data-view-name="profile-component-entity"]').first
             if await entity.count() == 0:
-                return None
+                return await self._parse_experience_from_links(item)
 
             children = await entity.locator("> *").all()
             if len(children) < 2:
-                return None
+                return await self._parse_experience_from_links(item)
 
             company_link = children[0].locator("a").first
             company_url = await company_link.get_attribute("href")
@@ -326,7 +523,7 @@ class PersonScraper(BaseScraper):
             detail_children = await detail_container.locator("> *").all()
 
             if len(detail_children) == 0:
-                return None
+                return await self._parse_experience_from_links(item)
 
             has_nested_positions = False
             if len(detail_children) > 1:
@@ -334,13 +531,16 @@ class PersonScraper(BaseScraper):
                 has_nested_positions = nested_list > 0
 
             if has_nested_positions:
-                return await self._parse_nested_experience(item, company_url, detail_children)
+                nested = await self._parse_nested_experience(item, company_url, detail_children)
+                if nested:
+                    return nested
+                return await self._parse_experience_from_links(item)
             else:
                 first_detail = detail_children[0]
                 nested_elements = await first_detail.locator("> *").all()
 
                 if len(nested_elements) == 0:
-                    return None
+                    return await self._parse_experience_from_links(item)
 
                 span_container = nested_elements[0]
                 outer_spans = await span_container.locator("> *").all()
@@ -363,6 +563,10 @@ class PersonScraper(BaseScraper):
                     aria_span = outer_spans[3].locator('span[aria-hidden="true"]').first
                     location = await aria_span.text_content()
 
+                company_name, employment_type = self._split_company_and_employment_type(
+                    company_name.strip() if company_name else ""
+                )
+
                 from_date, to_date, duration = self._parse_work_times(work_times)
 
                 description = ""
@@ -372,6 +576,7 @@ class PersonScraper(BaseScraper):
                 return Experience(
                     position_title=position_title.strip(),
                     institution_name=company_name.strip(),
+                    employment_type=employment_type,
                     linkedin_url=company_url,
                     from_date=from_date,
                     to_date=to_date,
@@ -382,6 +587,163 @@ class PersonScraper(BaseScraper):
 
         except Exception as e:
             logger.debug(f"Error parsing experience: {e}")
+            return None
+
+    async def _parse_experience_from_links(self, item) -> Optional[Experience]:
+        links = await item.locator("a, link").all()
+        if len(links) < 2:
+            return None
+
+        company_url = await links[0].get_attribute("href")
+        detail_link = links[1]
+
+        unique_texts = await self._extract_unique_texts_from_element(detail_link)
+        if len(unique_texts) < 2:
+            return None
+
+        position_title = unique_texts[0]
+        company_name, employment_type = self._split_company_and_employment_type(
+            unique_texts[1]
+        )
+
+        if not employment_type:
+            for text in unique_texts[2:]:
+                employment_type = self._extract_employment_type_from_text(text)
+                if employment_type:
+                    break
+
+        work_times = unique_texts[2] if len(unique_texts) > 2 else ""
+        location = unique_texts[3] if len(unique_texts) > 3 else ""
+
+        from_date, to_date, duration = self._parse_work_times(work_times)
+
+        return Experience(
+            position_title=position_title,
+            institution_name=company_name,
+            employment_type=employment_type,
+            linkedin_url=company_url,
+            from_date=from_date,
+            to_date=to_date,
+            duration=duration,
+            location=location,
+            description=None,
+        )
+
+    async def _is_grouped_experience_item(self, item) -> bool:
+        try:
+            grouped_items = await item.locator(
+                ".pvs-entity__sub-components .pvs-list__container .pvs-list__paged-list-item"
+            ).count()
+            return grouped_items > 0
+        except Exception:
+            return False
+
+    async def _parse_grouped_details_experience(self, item) -> list[Experience]:
+        """Parse grouped experience entries from details page."""
+        experiences = []
+
+        try:
+            entity = item.locator('div[data-view-name="profile-component-entity"]').first
+            if await entity.count() == 0:
+                return experiences
+
+            children = await entity.locator("> *").all()
+            if len(children) < 2:
+                return experiences
+
+            company_link = children[0].locator("a").first
+            company_url = await company_link.get_attribute("href")
+
+            detail_container = children[1]
+            detail_children = await detail_container.locator("> *").all()
+            header = detail_children[0] if detail_children else detail_container
+            header_texts = await self._extract_unique_texts_from_element(header)
+            company_name = header_texts[0] if header_texts else None
+            company_name, employment_type = self._split_company_and_employment_type(
+                company_name.strip() if company_name else ""
+            )
+            if not employment_type:
+                for text in header_texts[1:]:
+                    employment_type = self._extract_employment_type_from_text(text)
+                    if employment_type:
+                        break
+
+            nested_items = await detail_container.locator(
+                ".pvs-entity__sub-components .pvs-list__paged-list-item"
+            ).all()
+            if not nested_items:
+                return experiences
+
+            for nested_item in nested_items:
+                exp = await self._parse_grouped_detail_role(
+                    nested_item, company_name, company_url, employment_type
+                )
+                if exp:
+                    experiences.append(exp)
+
+        except Exception as e:
+            logger.debug(f"Error parsing grouped experience: {e}")
+
+        return experiences
+
+    async def _parse_grouped_detail_role(
+        self,
+        item,
+        company_name: Optional[str],
+        company_url: Optional[str],
+        employment_type: Optional[str],
+    ) -> Optional[Experience]:
+        """Parse a grouped role entry from details page."""
+        try:
+            link = item.locator("a").first
+            target = link if await link.count() > 0 else item
+            unique_texts = await self._extract_unique_texts_from_element(target)
+
+            if company_name:
+                unique_texts = [
+                    text
+                    for text in unique_texts
+                    if text.strip() != company_name.strip()
+                ]
+
+            if not unique_texts:
+                return None
+
+            position_title = unique_texts[0]
+            work_times = ""
+            location = ""
+
+            for text in unique_texts[1:]:
+                if not work_times and self._is_experience_time_text(text):
+                    work_times = text
+                    continue
+                if not location:
+                    location = text
+
+            from_date, to_date, duration = self._parse_work_times(work_times)
+
+            description = None
+            desc_container = item.locator(".pvs-entity__sub-components").first
+            if await desc_container.count() > 0:
+                desc_text = await desc_container.inner_text()
+                desc_text = desc_text.strip() if desc_text else ""
+                if desc_text:
+                    description = desc_text
+
+            return Experience(
+                position_title=position_title.strip(),
+                institution_name=company_name.strip() if company_name else None,
+                employment_type=employment_type,
+                linkedin_url=company_url,
+                from_date=from_date,
+                to_date=to_date,
+                duration=duration,
+                location=location.strip() if location else None,
+                description=description,
+            )
+
+        except Exception as e:
+            logger.debug(f"Error parsing grouped detail role: {e}")
             return None
 
     async def _parse_nested_experience(
@@ -405,9 +767,22 @@ class PersonScraper(BaseScraper):
 
             # First span is company name for nested positions
             company_name = ""
+            employment_type = None
             if len(outer_spans) >= 1:
                 aria_span = outer_spans[0].locator('span[aria-hidden="true"]').first
                 company_name = await aria_span.text_content()
+            for span in outer_spans[1:]:
+                aria_span = span.locator('span[aria-hidden="true"]').first
+                text = await aria_span.text_content()
+                employment_type = self._extract_employment_type_from_text(text)
+                if employment_type:
+                    break
+
+            company_name, header_employment_type = self._split_company_and_employment_type(
+                company_name.strip() if company_name else ""
+            )
+            if header_employment_type:
+                employment_type = header_employment_type
 
             # Get the nested list from detail_children[1]
             nested_container = detail_children[1].locator(".pvs-list__container").first
@@ -466,6 +841,7 @@ class PersonScraper(BaseScraper):
                         Experience(
                             position_title=position_title.strip(),
                             institution_name=company_name.strip(),
+                            employment_type=employment_type,
                             linkedin_url=company_url,
                             from_date=from_date,
                             to_date=to_date,

--- a/tests/fixtures/person_experience_details_grouped.html
+++ b/tests/fixtures/person_experience_details_grouped.html
@@ -1,0 +1,122 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <title>Experience Details Fixture</title>
+  </head>
+  <body>
+    <main>
+      <div class="pvs-list__container">
+        <ul>
+          <li class="pvs-list__paged-list-item">
+            <div>
+              <div data-view-name="profile-component-entity">
+                <div>
+                  <a href="https://www.linkedin.com/company/111111/">Logo</a>
+                </div>
+                <div class="display-flex flex-column align-self-center flex-grow-1">
+                  <div class="display-flex flex-row justify-space-between">
+                    <a
+                      class="optional-action-target-wrapper display-flex flex-column full-width"
+                      href="https://www.linkedin.com/company/111111/"
+                    >
+                      <div>
+                        <div>
+                          <span aria-hidden="true">Example Holdings</span>
+                        </div>
+                      </div>
+                      <span aria-hidden="true">Full-time &middot; 7 yrs</span>
+                    </a>
+                  </div>
+                  <div class="pvs-entity__sub-components">
+                    <div class="pvs-list__container">
+                      <ul>
+                        <li class="pvs-list__paged-list-item pvs-list__item--one-column">
+                          <div data-view-name="profile-component-entity">
+                            <div></div>
+                            <div class="display-flex flex-column align-self-center flex-grow-1">
+                              <div class="display-flex flex-row justify-space-between">
+                                <a
+                                  class="optional-action-target-wrapper display-flex flex-column full-width"
+                                  href="https://www.linkedin.com/in/example/add-edit/POSITION/1"
+                                >
+                                  <div>
+                                    <div>
+                                      <span aria-hidden="true">Lead Engineer</span>
+                                    </div>
+                                  </div>
+                                  <span aria-hidden="true">Jan 2021 - Present · 5 yrs 2 mos</span>
+                                  <span aria-hidden="true">Sample City, Country</span>
+                                </a>
+                              </div>
+                              <div class="pvs-entity__sub-components">
+                                <span aria-hidden="true">- Led API work.</span>
+                              </div>
+                            </div>
+                          </div>
+                        </li>
+                        <li class="pvs-list__paged-list-item pvs-list__item--one-column">
+                          <div data-view-name="profile-component-entity">
+                            <div></div>
+                            <div class="display-flex flex-column align-self-center flex-grow-1">
+                              <div class="display-flex flex-row justify-space-between">
+                                <a
+                                  class="optional-action-target-wrapper display-flex flex-column full-width"
+                                  href="https://www.linkedin.com/in/example/add-edit/POSITION/2"
+                                >
+                                  <div>
+                                    <div>
+                                      <span aria-hidden="true">Full Stack Developer</span>
+                                    </div>
+                                  </div>
+                                  <span aria-hidden="true">Mar 2019 - Jan 2021 · 1 yr 11 mos</span>
+                                  <span aria-hidden="true">Metro Region</span>
+                                </a>
+                              </div>
+                              <div class="pvs-entity__sub-components">
+                                <span aria-hidden="true">- Built internal tools.</span>
+                              </div>
+                            </div>
+                          </div>
+                        </li>
+                      </ul>
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </li>
+          <li class="pvs-list__paged-list-item">
+            <div>
+              <div data-view-name="profile-component-entity">
+                <div>
+                  <a href="https://www.linkedin.com/company/222222/">Logo</a>
+                </div>
+                <div class="display-flex flex-column align-self-center flex-grow-1">
+                  <div class="display-flex flex-row justify-space-between">
+                    <a
+                      class="optional-action-target-wrapper display-flex flex-column full-width"
+                      href="https://www.linkedin.com/in/example/add-edit/POSITION/3"
+                    >
+                      <div>
+                        <div>
+                          <span aria-hidden="true">Software Engineer</span>
+                        </div>
+                      </div>
+                      <span aria-hidden="true">Acme Labs &middot; Contract</span>
+                      <span aria-hidden="true">Apr 2018 - Dec 2018 · 9 mos</span>
+                      <span aria-hidden="true">Coastal Region</span>
+                    </a>
+                  </div>
+                  <div class="pvs-entity__sub-components">
+                    <span aria-hidden="true">- Implemented new features.</span>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </li>
+        </ul>
+      </div>
+    </main>
+  </body>
+</html>

--- a/tests/fixtures/person_experience_grouped.html
+++ b/tests/fixtures/person_experience_grouped.html
@@ -1,0 +1,59 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <title>Grouped Experience Fixture</title>
+  </head>
+  <body>
+    <section>
+      <div>
+        <h2>Experience</h2>
+      </div>
+      <div>
+        <ul>
+          <li>
+            <div data-view-name="profile-component-entity">
+              <div>
+                <a href="https://www.linkedin.com/company/999999/">Logo</a>
+              </div>
+              <div>
+                <a href="https://www.linkedin.com/company/999999/">
+                  <span aria-hidden="true">Example Corp</span>
+                  <span aria-hidden="true">Full-time &middot; 2 yrs 1 mo</span>
+                  <span aria-hidden="true">Sample City, Country &middot; On-site</span>
+                </a>
+              </div>
+              <div class="pvs-entity__sub-components">
+                <ul>
+                  <li>
+                    <div data-view-name="profile-component-entity">
+                      <div></div>
+                      <div>
+                        <a href="https://www.linkedin.com/company/999999/">
+                          <span aria-hidden="true">Mobile Engineer</span>
+                          <span aria-hidden="true">Oct 2021 - Aug 2022</span>
+                          <span aria-hidden="true">Remote</span>
+                        </a>
+                      </div>
+                    </div>
+                  </li>
+                  <li>
+                    <div data-view-name="profile-component-entity">
+                      <div></div>
+                      <div>
+                        <a href="https://www.linkedin.com/company/999999/">
+                          <span aria-hidden="true">Backend Engineer</span>
+                          <span aria-hidden="true">Aug 2020 - Oct 2021</span>
+                        </a>
+                      </div>
+                    </div>
+                  </li>
+                </ul>
+              </div>
+            </div>
+          </li>
+        </ul>
+      </div>
+    </section>
+  </body>
+</html>

--- a/tests/test_person_scraper.py
+++ b/tests/test_person_scraper.py
@@ -1,4 +1,6 @@
 """Tests for PersonScraper."""
+from pathlib import Path
+
 import pytest
 from linkedin_scraper import PersonScraper
 from linkedin_scraper.models import Person
@@ -125,3 +127,88 @@ def test_person_model_to_json():
     json_str = person.to_json()
     assert isinstance(json_str, str)
     assert "Test User" in json_str
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_person_scraper_grouped_experiences_main_page(browser, silent_callback):
+    """Parse grouped main-page experiences without misassigning company names."""
+    fixture_path = Path(__file__).parent / "fixtures" / "person_experience_grouped.html"
+    html = fixture_path.read_text(encoding="utf-8")
+
+    await browser.page.set_content(html)
+
+    scraper = PersonScraper(browser.page, callback=silent_callback)
+    experiences = await scraper._get_experiences_from_main_page()
+
+    assert len(experiences) == 2
+    titles = {exp.position_title for exp in experiences}
+    assert titles == {"Mobile Engineer", "Backend Engineer"}
+    assert all(exp.institution_name == "Example Corp" for exp in experiences)
+    assert all(exp.employment_type == "Full-time" for exp in experiences)
+    assert all(
+        exp.linkedin_url == "https://www.linkedin.com/company/999999/"
+        for exp in experiences
+    )
+
+    mobile = next(exp for exp in experiences if exp.position_title == "Mobile Engineer")
+    assert mobile.from_date == "Oct 2021"
+    assert mobile.to_date == "Aug 2022"
+    assert mobile.duration is None
+    assert mobile.location == "Remote"
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_person_scraper_grouped_experiences_details_page(browser, silent_callback):
+    """Parse grouped details-page experiences without misassigning company names."""
+    fixture_path = (
+        Path(__file__).parent / "fixtures" / "person_experience_details_grouped.html"
+    )
+    html = fixture_path.read_text(encoding="utf-8")
+
+    await browser.page.set_content(html)
+
+    scraper = PersonScraper(browser.page, callback=silent_callback)
+    items = await browser.page.locator(".pvs-list__paged-list-item").all()
+    experiences = []
+
+    for item in items:
+        result = await scraper._parse_experience_item(item)
+        if result:
+            if isinstance(result, list):
+                experiences.extend(result)
+            else:
+                experiences.append(result)
+
+    assert len(experiences) == 3
+
+    example_roles = [
+        exp for exp in experiences if exp.institution_name == "Example Holdings"
+    ]
+    assert {exp.position_title for exp in example_roles} == {
+        "Lead Engineer",
+        "Full Stack Developer",
+    }
+    assert all(
+        exp.linkedin_url == "https://www.linkedin.com/company/111111/"
+        for exp in example_roles
+    )
+    assert all(exp.employment_type == "Full-time" for exp in example_roles)
+
+    technical = next(
+        exp for exp in example_roles if exp.position_title == "Lead Engineer"
+    )
+    assert technical.from_date == "Jan 2021"
+    assert technical.to_date == "Present"
+    assert technical.duration == "5 yrs 2 mos"
+    assert technical.location == "Sample City, Country"
+    assert technical.description and "Led API work" in technical.description
+
+    pixx = next(exp for exp in experiences if exp.position_title == "Software Engineer")
+    assert pixx.institution_name == "Acme Labs"
+    assert pixx.employment_type == "Contract"
+    assert pixx.from_date == "Apr 2018"
+    assert pixx.to_date == "Dec 2018"
+    assert pixx.duration == "9 mos"
+    assert pixx.location == "Coastal Region"


### PR DESCRIPTION
## Summary

This PR enhances the `PersonScraper` with improved experience extraction capabilities:

- **Employment Type Extraction**: Added support for extracting employment type (Full-time, Part-time, Contract, Freelance, etc.) from experience entries
- **Grouped Experience Parsing**: Improved parsing of grouped/nested experiences where multiple roles are listed under a single company
- **Better Fallback Logic**: Details page is now tried first, with main page as fallback for more reliable data extraction

## Changes

### Models
- Added `employment_type` field to the `Experience` model

### Person Scraper
- Added `EMPLOYMENT_TYPE_MAP` for normalizing employment type values
- New methods for parsing grouped experiences:
  - `_get_experiences_from_details()` - Extract from details/experience page
  - `_get_experiences_from_main_page()` - Fallback extraction from main profile
  - `_parse_grouped_main_page_role()` - Parse nested roles on main page
  - `_parse_grouped_details_experience()` - Parse grouped entries from details page
  - `_parse_grouped_detail_role()` - Parse individual role in grouped experience
- Helper methods:
  - `_is_experience_time_text()` - Detect date/duration text
  - `_normalize_employment_type()` - Normalize employment type strings
  - `_extract_employment_type_from_text()` - Extract employment type from text
  - `_split_company_and_employment_type()` - Split company name from employment type

### Tests
- Added HTML fixtures for grouped experiences (main page and details page)
- Added unit tests for grouped experience parsing