### PR TITLE
fix(utils): use inner_text() in rate limit detection

### DIFF
--- a/linkedin_scraper/core/utils.py
+++ b/linkedin_scraper/core/utils.py
@@ -88,7 +88,7 @@ async def detect_rate_limit(page: Page) -> None:
     
     # Check for rate limit messages
     try:
-        body_text = await page.locator('body').text_content(timeout=1000)
+        body_text = await page.locator('body').inner_text(timeout=1000)
         if body_text:
             body_lower = body_text.lower()
             if any(phrase in body_lower for phrase in [


### PR DESCRIPTION
`detect_rate_limit()` false-fires on every page because `text_content()` picks up invisible React RSC serialized JSON that LinkedIn now embeds in the DOM. The phrase `"something went wrong. please try again later."` appears inside preloaded RSC data like:

```
"children":["something went wrong. please try again later."]
```

This matches the `"try again later"` check and raises `RateLimitError` even on perfectly normal pages.

**Fix:** Switch from `text_content()` to `inner_text()` to return only visible text, which is already the pattern used in all the scrapers (`person.py`, `company.py`, `job.py`).

Resolves #277, likely fixes #275